### PR TITLE
Adds audio test reporter via "say" command when SPEAK_TEST_RESULTS is set

### DIFF
--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -15,6 +15,7 @@
    [mb.hawk.init :as hawk.init]
    [mb.hawk.junit :as hawk.junit]
    [mb.hawk.parallel :as hawk.parallel]
+   [mb.hawk.speak :as hawk.speak]
    [mb.hawk.util :as u]))
 
 (set! *warn-on-reflection* true)
@@ -145,6 +146,7 @@
                           :cli/local      eftest.report.progress/report)]
     (fn handle-event [event]
       (hawk.junit/handle-event! event)
+      (hawk.speak/handle-event! event)
       (stdout-reporter event))))
 
 (def ^:private env-mode

--- a/src/mb/hawk/speak.clj
+++ b/src/mb/hawk/speak.clj
@@ -1,0 +1,22 @@
+(ns mb.hawk.speak
+  (:require [clojure.java.shell :as sh]))
+
+(defmulti handle-event!
+  "Handles a test event by speaking(!?) it if appropriate"
+  :type)
+
+(defn- enabled? [] (some? (System/getenv "SPEAK_TEST_RESULTS")))
+
+(defmethod handle-event! :default [_] nil)
+
+(defmethod handle-event! :summary
+  [{:keys [error fail]}]
+  (when (enabled?)
+    (apply sh/sh "say"
+           (if (zero? (+ error fail))
+             "all tests passed"
+             "tests failed")
+           (for [[n s] [[error "error"]
+                        [fail  "failure"]]
+                 :when (pos? n)]
+             (str n " " s (when (< 1 n) "s"))))))

--- a/test/mb/hawk/speak_test.clj
+++ b/test/mb/hawk/speak_test.clj
@@ -1,0 +1,16 @@
+(ns mb.hawk.speak-test
+  (:require [clojure.java.shell :as sh]
+            [clojure.test :refer :all]
+            [mb.hawk.speak :as hawk.speak]))
+
+(deftest speak-results-test
+  (are [error fail expected] (let [sh-args (atom nil)]
+                            (with-redefs [hawk.speak/enabled? (constantly true)
+                                          sh/sh               (fn [& args] (reset! sh-args (vec args)))]
+                              (hawk.speak/handle-event! {:type :summary :error error :fail fail})
+                              (= (into ["say"] expected) @sh-args)))
+    0 0 ["all tests passed"]
+    1 0 ["tests failed" "1 error"]
+    2 0 ["tests failed" "2 errors"]
+    2 1 ["tests failed" "2 errors" "1 failure"]
+    0 2 ["tests failed" "2 failures"]))


### PR DESCRIPTION
This was a feature of the test harness on a previous project and it was very useful for a lot of folks, myself included. I was using a shell alias to get something sort of like this, but I decided to try incorporating it into Hawk to allow it to work with either the REPL or the CLI.