### PR TITLE
Don't double evaluate schemas in `#hawk/malli`

### DIFF
--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -110,7 +110,7 @@
 (defn read-exactly
   "Data reader for `#hawk/exactly`."
   [expected-form]
-  (->Exactly (eval expected-form)))
+  `(->Exactly ~expected-form))
 
 (defmethod print-method Exactly
   [this writer]
@@ -137,7 +137,7 @@
 (defn read-schema
   "Data reader for `#hawk/schema`."
   [schema-form]
-  (->Schema (eval schema-form)))
+  `(->Schema ~schema-form))
 
 (defmethod print-method Schema
   [this writer]
@@ -162,7 +162,7 @@
 (defn read-malli
   "Data reader for `#hawk/malli`."
   [schema-form]
-  (->Malli (eval schema-form)))
+  `(->Malli ~schema-form))
 
 (defmethod print-dup Malli
   [^Malli this ^java.io.Writer writer]

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -1,6 +1,7 @@
 (ns mb.hawk.assert-exprs.approximately-equal-test
   (:require
    [clojure.test :refer :all]
+   [malli.core :as m]
    [mb.hawk.assert-exprs :as test-runner.assert-exprs]
    [mb.hawk.assert-exprs.approximately-equal :as approximately-equal]
    [schema.core :as s]))
@@ -136,7 +137,14 @@
       (testing "Inside a collection"
         (is (= '{:b {:c ["should be an integer"]}}
                (read-string (pr-str (approximately-equal/=?-diff {:a 1, :b #hawk/malli [:map [:c :int]]}
-                                                                 {:a 1, :b {:c 2.0}})))))))))
+                                                                 {:a 1, :b {:c 2.0}})))))))
+    (testing "Doesn't double evaluate functions (#12)"
+      (let [schema #hawk/malli [:map [:k map?]]]
+        (is (identical? map? (-> (.schema schema) last last))
+            "Got a double compiled function in schema")
+        (is (m/validate (.schema schema) {:k {}}))))))
+
+
 (deftest ^:parallel approx-test
   (testing "#hawk/approx"
     (is (=? #hawk/approx [1.5 0.1]


### PR DESCRIPTION
Fixes #12

The gist is that reader macros are passing a form to be evaluated. So if they call `eval` we double evaluate things and that can be a _very_ subtle footgun.

In particular, malli has core functions (like `map?`) in a registry. So when you use a function, it looks it up in that registry. Functions have reference identity (location in memory) so if we get a different copy of `map?` it fails to find a schema for it and it breaks.

```clojure
;; double evaluation changes things:
user=> (let [single (eval '[:vector map?])
             double (eval single)]
         {:single-identical? (identical? map? (last single))
          :double-identical? (identical? map? (last double))})
{:single-identical? true, :double-identical? false}

;; showing different locations in memory:
user=> (let [schema #hawk/malli [:map [:k [:maybe map?]]]]
         [map? (-> (.schema schema) last last last)])
[#object[clojure.core$map_QMARK___5489
         "0xe0847a9"
         "clojure.core$map_QMARK___5489@e0847a9"]
 #object[clojure.core$map_QMARK___5489
         "0x2b812add"  ;; not= to "0xe0847a9 above
         "clojure.core$map_QMARK___5489@2b812add"]]
```

And the ultimate test is that the schemas fail:

```clojure
user=> (let [schema #hawk/malli [:map [:k [:maybe map?]]]]
         (malli.core/validate (.schema schema)
                              {:k {}}))
Execution error (ExceptionInfo) at malli.core/-exception (core.cljc:138).
:malli.core/invalid-schema
user=> (let [schema [:map [:k [:maybe map?]]]]
         (malli.core/validate schema
                              {:k {}}))
true
```