### PR TITLE
Replace reader tags with functions

### DIFF
--- a/docs/approximately-equal.md
+++ b/docs/approximately-equal.md
@@ -53,77 +53,83 @@ aren't. In this case, it returns something like
 
 This is printed in the correct place by humanized test output and other things that can print diffs.
 
-## Reader tags:
+## Built-in functions for other `=?` behaviors:
 
-### `#hawk/exactly`
+Built-in functions for `=?` are defined in the `mb.hawk.assert-exprs.approximately-equal` namespace. You can create
+an alias for this namespace like so:
+```clj
+(require '[mb.hawk.assert-exprs.approximately-equal :as =?])
+```
 
-`#hawk/exactly` means results have to be exactly equal as if by `=`. Use this to get around the normal way `=?` would
+### `exactly`
+
+`exactly` means results have to be exactly equal as if by `=`. Use this to get around the normal way `=?` would
 compare things. This works inside collections as well.
 
 ```clj
-(is (=? {:m #hawk/exactly {:a 1}}
+(is (=? {:m (=?/exactly {:a 1})}
         {:m {:a 1, :b 2}}))
 ;; =>
-expected: {:m #hawk/exactly {:a 1}}
+expected: {:m (exactly {:a 1})}
 
   actual: {:m {:a 1, :b 2}}
-    diff: - {:m (not (= #hawk/exactly {:a 1} {:a 1, :b 2}))}
+    diff: - {:m (not (= (exactly {:a 1}) {:a 1, :b 2}))}
           + nil
 ```
 
-### `#hawk/schema`
+### `schema`
 
-`#hawk/schema` compares things to a `schema.core` Schema:
+`schema` compares things to a `schema.core` Schema:
 
 ```clj
-(is (=? {:a 1, :b #hawk/schema {s/Keyword s/Int}}
+(is (=? {:a 1, :b (=?/schema {s/Keyword s/Int})}
         {:a 1, :b {:c 2}}))
 => ok
 
-(is (=? {:a 1, :b #hawk/schema {s/Keyword s/Int}}
+(is (=? {:a 1, :b (=?/schema {s/Keyword s/Int})}
         {:a 1, :b {:c 2.0}}))
 =>
-expected: {:a 1, :b #hawk/schema {(pred keyword?) (pred integer?)}}
+expected: {:a 1, :b (schema {(pred keyword?) (pred integer?)})}
 
   actual: {:a 1, :b {:c 2.0}}
     diff: - {:b {:c (not (integer? 2.0))}}
           + nil
 ```
 
-### `#hawk/malli`
+### `malli`
 
-`#hawk/malli` compares things to a `malli` schema:
+`malli` compares things to a `malli` schema:
 
 ```clj
-(is (=? {:a 1, :b #hawk/malli [:map-of :keyword :int]}
+(is (=? {:a 1, :b (=?/malli [:map-of :keyword :int])}
         {:a 1, :b {:c 2}}))
 => ok
 
-(is (=? {:a 1, :b #hawk/malli [:map-of :keyword :int]}
+(is (=? {:a 1, :b (=?/malli [:map-of :keyword :int])}
         {:a 1, :b {:c 2.0}}))
 =>
-expected: {:a 1, :b #hawk/malli [:map-of :keyword :int]}
+expected: {:a 1, :b (malli [:map-of :keyword :int])}
   actual: {:a 1, :b {:c 2.0}}
     diff: - {:b {:c ["should be an integer"]}}
 
 ```
 
-### `#hawk/approx`
+### `approx`
 
-`#hawk/approx` compares whether two numbers are approximately equal:
+`approx` compares whether two numbers are approximately equal:
 
 ```clj
 ;; is the difference between actual and 1.5 less than ±0.1?
-(is (=? #hawk/approx [1.5 0.1]
+(is (=? (=?/approx [1.5 0.1])
         1.51))
 => true
 
-(is (=? #hawk/approx [1.5 0.1]
+(is (=? (=?/approx [1.5 0.1])
         1.6))
 =>
-expected: #hawk/approx [1.5 0.1]
+expected: (approx [1.5 0.1])
 
   actual: 1.6
-    diff: - (not (approx= 1.5 1.6 #_epsilon 0.1))
+    diff: - (not (approx 1.5 1.6 #_epsilon 0.1))
           + nil
 ```

--- a/resources/data_readers.clj
+++ b/resources/data_readers.clj
@@ -1,4 +1,0 @@
-{hawk/exactly mb.hawk.assert-exprs.approximately-equal/read-exactly
- hawk/schema  mb.hawk.assert-exprs.approximately-equal/read-schema
- hawk/malli   mb.hawk.assert-exprs.approximately-equal/read-malli
- hawk/approx  mb.hawk.assert-exprs.approximately-equal/read-approx}

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -1,7 +1,6 @@
 (ns mb.hawk.assert-exprs.approximately-equal-test
   (:require
    [clojure.test :refer :all]
-   [malli.core :as m]
    [mb.hawk.assert-exprs :as test-runner.assert-exprs]
    [mb.hawk.assert-exprs.approximately-equal :as =?]
    [schema.core :as s]))
@@ -137,13 +136,7 @@
       (testing "Inside a collection"
         (is (= '{:b {:c ["should be an integer"]}}
                (read-string (pr-str (=?/=?-diff {:a 1, :b (=?/malli [:map [:c :int]])}
-                                                {:a 1, :b {:c 2.0}})))))))
-    (testing "Doesn't double evaluate functions (#12)"
-      (let [schema (=?/malli [:map [:k map?]])]
-        (is (identical? map? (-> (.schema schema) last last))
-            "Got a double compiled function in schema")
-        (is (m/validate (.schema schema) {:k {}}))))))
-
+                                                {:a 1, :b {:c 2.0}})))))))))
 
 (deftest ^:parallel approx-test
   (testing "=?/approx"


### PR DESCRIPTION
This PR is a breaking change. It replaces the reader tags defined in [data_readers.clj](https://github.com/metabase/hawk/blob/93495c6d5ca3704d5edc4d915f92dae43c9f5045/resources/data_readers.clj) with functions, per [Proposal: use malli=? instead of #hawk/malli etc](https://github.com/metabase/metabase/pull/35481).

Example of how this changes user code:
```diff
- (is (=? #hawk/malli [:map [:a :int]] {:a 1})
+ (is (=? (=?/malli [:map [:a :int]]) {:a 1})
```

See the full set of differences by comparing the [docs](https://github.com/metabase/hawk/pull/14/files#diff-c7db5608c6c0903f56d83de5b6a808180bf924849c1788b27dbc0437f7498a5b).

I chose to name the functions to be alphabetic characters only, like `malli` and not `malli=` or `malli=?`, because they are intended to be required into a user code with `(require '[mb.hawk.assert-exprs.approximately-equal :as =?])`. `=?/malli` is sufficient to demonstrate its meaning without more characters.