### PR TITLE
Option to run test n times

### DIFF
--- a/.clj-kondo/com.github.metabase/hawk/config.edn
+++ b/.clj-kondo/com.github.metabase/hawk/config.edn
@@ -1,4 +1,4 @@
 {:linters
  {:unresolved-symbol
   {:exclude
-   [(clojure.test/is [partial= query= re= schema= sql= =?])]}}}
+   [(clojure.test/is [partial= re= schema= =?])]}}}

--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -194,9 +194,9 @@
   [test-vars options n]
   (printf "Running tests %d times\n" n)
   (reduce (fn [acc test-result] (merge-with
-                                 #(if (number? %1)
+                                 #(if (number? %2)
                                     (+ %1 %2)
-                                    %1)
+                                    %2)
                                  acc
                                  test-result))
           (for [i (range 1 (inc n))]

--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -203,7 +203,7 @@
   (apply merge-with (fn [x y] (if (number? x)
                                 (+ x y)
                                 y))
-         (for [i (range n)]
+         (for [i (range 1 (inc n))]
            (do
             (println "----------------------------")
             (printf "Running tests the %s %s\n" (ordinal-str i) (if (> 1 i) "times" "time"))

--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -193,14 +193,17 @@
   Returns the combined summary of all the individual test runs."
   [test-vars options n]
   (printf "Running tests %d times\n" n)
-  (apply merge-with (fn [x y] (if (number? x)
-                                (+ x y)
-                                y))
-         (for [i (range 1 (inc n))]
-           (do
-            (println "----------------------------")
-            (printf "Starting test iteration #%d\n" i)
-            (run-tests test-vars options)))))
+  (reduce (fn [acc test-result] (merge-with
+                                 #(if (number? %1)
+                                    (+ %1 %2)
+                                    %1)
+                                 acc
+                                 test-result))
+          (for [i (range 1 (inc n))]
+            (do
+             (println "----------------------------")
+             (printf "Starting test iteration #%d\n" i)
+             (run-tests test-vars options)))))
 
 (defn- find-and-run-tests-with-options
   "Entrypoint for the test runner. `options` are passed directly to `eftest`; see https://github.com/weavejester/eftest

--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -188,13 +188,6 @@
             options))
           @*parallel-test-counter*))))))
 
-(defn- ordinal-str
-  [n]
-  (let [suffix (if (and (>= n 11) (<= (mod n 100) 13))
-                 "th"
-                 (nth ["th" "st" "nd" "rd" "th"] (min (mod n 10) 4)))]
-    (str n suffix)))
-
 (defn- run-tests-n-times
   "[[run-tests]] but repeat `n` times.
   Returns the combined summary of all the individual test runs."
@@ -206,7 +199,7 @@
          (for [i (range 1 (inc n))]
            (do
             (println "----------------------------")
-            (printf "Running tests the %s %s\n" (ordinal-str i) (if (> 1 i) "times" "time"))
+            (printf "Starting test iteration #%d\n" i)
             (run-tests test-vars options)))))
 
 (defn- find-and-run-tests-with-options

--- a/test/mb/hawk/core_test.clj
+++ b/test/mb/hawk/core_test.clj
@@ -52,19 +52,3 @@
     {:exclude-tags [:exclude-tags-test :another/tag]})
   (is (not (contains? (set (hawk/find-tests nil {:exclude-tags [:exclude-tags-test]}))
                       #'find-tests-test))))
-
-(deftest run-tests-n-times-test
-  (let [single-run-summary {:test            10
-                            :pass            5
-                            :fail            3
-                            :error           2
-                            :duration        1
-                            :single-threaded 1}]
-    (with-redefs [hawk/run-tests (fn [& _args] single-run-summary)]
-      (testing "run single time"
-        (is (= single-run-summary
-               (hawk/find-and-run-tests-repl {:times 1}))))
-
-      (testing "run multiple will combine the summary of all the runs"
-        (is (= (apply merge-with + (repeat 3 single-run-summary))
-               (hawk/find-and-run-tests-repl {:times 3})))))))

--- a/test/mb/hawk/core_test.clj
+++ b/test/mb/hawk/core_test.clj
@@ -63,8 +63,8 @@
     (with-redefs [hawk/run-tests (fn [& _args] single-run-summary)]
       (testing "run single time"
        (is (= single-run-summary
-              (hawk/find-and-run-tests-repl {:only 'mb.hawk.core-test/dummy-test :times 1}))))
+              (hawk/find-and-run-tests-repl {:times 1}))))
 
       (testing "run multiple will combine the summary of all the runs"
        (is (= (apply merge-with + (repeat 3 single-run-summary))
-              (hawk/find-and-run-tests-repl {:only 'mb.hawk.core-test/dummy-test :times 3})))))))
+              (hawk/find-and-run-tests-repl {:times 3})))))))

--- a/test/mb/hawk/core_test.clj
+++ b/test/mb/hawk/core_test.clj
@@ -52,3 +52,19 @@
     {:exclude-tags [:exclude-tags-test :another/tag]})
   (is (not (contains? (set (hawk/find-tests nil {:exclude-tags [:exclude-tags-test]}))
                       #'find-tests-test))))
+
+(deftest run-tests-n-times-test
+  (let [single-run-summary {:test            10
+                            :pass            5
+                            :fail            3
+                            :error           2
+                            :duration        1
+                            :single-threaded 1}]
+    (with-redefs [hawk/run-tests (fn [& _args] single-run-summary)]
+      (testing "run single time"
+       (is (= single-run-summary
+              (hawk/find-and-run-tests-repl {:only 'mb.hawk.core-test/dummy-test :times 1}))))
+
+      (testing "run multiple will combine the summary of all the runs"
+       (is (= (apply merge-with + (repeat 3 single-run-summary))
+              (hawk/find-and-run-tests-repl {:only 'mb.hawk.core-test/dummy-test :times 3})))))))

--- a/test/mb/hawk/core_test.clj
+++ b/test/mb/hawk/core_test.clj
@@ -62,9 +62,9 @@
                             :single-threaded 1}]
     (with-redefs [hawk/run-tests (fn [& _args] single-run-summary)]
       (testing "run single time"
-       (is (= single-run-summary
-              (hawk/find-and-run-tests-repl {:times 1}))))
+        (is (= single-run-summary
+               (hawk/find-and-run-tests-repl {:times 1}))))
 
       (testing "run multiple will combine the summary of all the runs"
-       (is (= (apply merge-with + (repeat 3 single-run-summary))
-              (hawk/find-and-run-tests-repl {:times 3})))))))
+        (is (= (apply merge-with + (repeat 3 single-run-summary))
+               (hawk/find-and-run-tests-repl {:times 3})))))))


### PR DESCRIPTION
Cmd option for https://github.com/metabase/hawk/issues/15

Add `:times` option to run tests `n` times.

```bash
> clj -X:dev:test :only metabase.api.user-test/user-list-authentication-test :times 3
Running tests with options {:mode :cli/local, :namespace-pattern #"^metabase.*", :exclude-directories ["classes" "dev" "enterprise/backend/src" "local" "resources" "resources-ee" "src" "target" "test_config" "test_resources"], :test-warn-time 3000, :only metabase.api.user-test/user-list-authentication-test, :times 3}
Running tests in metabase.api.user-test/user-list-authentication-test
Finding tests took 10.1 s.
Running 1 tests
Running tests 3 times
----------------------------
Starting test iteration #1

1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 2.168 seconds
4 assertions, 0 failures, 0 errors.
----------------------------
Starting test iteration #2

1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 0.003 seconds
4 assertions, 0 failures, 0 errors.
----------------------------
Starting test iteration #3

1/1   100% [==================================================]  ETA: 00:00

Ran 1 tests in 0.002 seconds
4 assertions, 0 failures, 0 errors.
{:test 3, :pass 12, :fail 0, :error 0, :type :summary, :duration 2173.4457509999997, :single-threaded 3}
Ran 0 tests in parallel, 3 single-threaded.
Finding and running tests took 12.9 s.
All tests passed.
```