### PR TITLE
Respect parallel false on var

### DIFF
--- a/src/mb/hawk/parallel.clj
+++ b/src/mb/hawk/parallel.clj
@@ -8,8 +8,9 @@
   "Whether `test-var` can be ran in parallel with other parallel tests."
   [test-var]
   (let [metta (meta test-var)]
-    (or (:parallel metta)
-        (:parallel (-> metta :ns meta)))))
+    (if-some [var-parallel (:parallel metta)]
+      var-parallel
+      (:parallel (-> metta :ns meta)))))
 
 (def ^:private synchronized? (complement parallel?))
 

--- a/test/mb/hawk/parallel_test.clj
+++ b/test/mb/hawk/parallel_test.clj
@@ -1,0 +1,10 @@
+(ns ^:parallel mb.hawk.parallel-test
+  (:require
+   [clojure.test :refer :all]
+   [mb.hawk.parallel :as parallel]))
+
+(deftest ns-parallel-test
+  (is parallel/*parallel?*))
+
+(deftest ^{:parallel false} var-not-parallel-test
+  (is (not parallel/*parallel?*)))


### PR DESCRIPTION
Setting parallel false on var while ns has parallel true still leaves the test parallel. This PR fixes that.
