### PR TITLE
Exclude individual tests by tag

### DIFF
--- a/src/mb/hawk/core.clj
+++ b/src/mb/hawk/core.clj
@@ -75,23 +75,18 @@
   [(or (resolve symb)
        (throw (ex-info (format "Unable to resolve test named %s" symb) {:test-symbol symb})))])
 
-(defn- excluded-element-tags
+(defn- excluded-tags
   "Return the set of all tags in an element's metadata that are also in the `:exclude-tags` options."
   [element options]
   (when-let [excluded-tags (not-empty (set (:exclude-tags options)))]
     (let [ns-tags (-> element meta keys set)]
       (not-empty (set/intersection excluded-tags ns-tags)))))
 
-(defn- excluded-namespace-tags
-  "Return a set of all tags in a namespace metadata that are also in the `:exclude-tags` options."
-  [ns-symb options]
-  (excluded-element-tags (find-ns ns-symb) options))
-
 (defn- filter-tests-by-tag
   "Filter out the test cases with tags that are also in the `:exclude-tags` options."
   [tests options]
   (filter (fn [test]
-            (if-let [excluded-tags (not-empty (excluded-element-tags test options))]
+            (if-let [excluded-tags (not-empty (excluded-tags test options))]
               (println (format
                         "Skipping test `%s` due to excluded tag(s): %s"
                         (:name (meta test))
@@ -102,7 +97,7 @@
 (defn- find-tests-for-namespace-symbol
   [ns-symb options]
   (load-test-namespace ns-symb)
-  (if-let [excluded-tags (not-empty (excluded-namespace-tags ns-symb options))]
+  (if-let [excluded-tags (not-empty (excluded-tags (find-ns ns-symb) options))]
     (println (format
               "Skipping tests in `%s` due to excluded tag(s): %s"
               ns-symb


### PR DESCRIPTION
Closes https://github.com/metabase/hawk/issues/20

Note that I'm not bothering to exclude tests when they are referenced explicitly. This is inconsistent with filtering namespaces when they are reference explicitly, so perhaps we want to change this. I couldn't convince myself it was worth a more complex implementation however.