### PR TITLE
Same type for asserting occurrences of same value

### DIFF
--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -255,7 +255,7 @@
     (if (contains? @*same* (.k this))
       (let [previous-value (get @*same* (.k this))]
         (when-not (= previous-value actual)
-          (list 'not= previous-value actual)))
+          (list 'not= (symbol "#_") (list 'same (.k this)) previous-value actual)))
       (do
         (swap! *same* assoc (.k this) actual)
         nil))))

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -165,3 +165,25 @@
     (testing "nil should not match the =?/approx method -- fall back to the :default"
       (is (= "(not= (approx [1 0.1]) nil)"
              (pr-str (=?/=?-diff (=?/approx [1 0.1]) nil)))))))
+
+(deftest ^:parallel same-test
+  (testing "pr-str"
+    (is (= "(same :a)" (pr-str (=?/same :a)))))
+  (testing "Same does nothing with 1 occurrence"
+    (is (=? (=?/same :a) 1)))
+  (testing "Multiple occurrences are the same"
+    (is (=? [(=?/same :a) (=?/same :b) (=?/same :b) (=?/same :a)] [1 2 2 1])))
+  (testing "Works nested"
+    (is (=? [(=?/same :a) {:nested (=?/same :a)}] [1 {:nested 1}])))
+  (testing "Works on complex values"
+    (is (=? [(=?/same :a) {:nested (=?/same :a)}] [#{1 2 3} {:nested #{1 2 3}}])))
+  (testing "When not the same"
+    (is (= "[nil (not= 1 2)]"
+           (pr-str (=?/=?-diff* [(=?/same :a) (=?/same :a)] [1 2]))))
+    (is (= "[nil (not= 1 2) nil (not= 2 3)]"
+           (pr-str (=?/=?-diff* [(=?/same :a) (=?/same :a)
+                                 (=?/same :b) (=?/same :b)]
+                                [1 2 2 3]))))
+    (testing "Not the same and nested"
+      (is (= "[nil {:nested (not= 1 2)}]"
+             (pr-str (=?/=?-diff* [(=?/same :a) {:nested (=?/same :a)}] [1 {:nested 2}])))))))

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -178,12 +178,12 @@
   (testing "Works on complex values"
     (is (=? [(=?/same :a) {:nested (=?/same :a)}] [#{1 2 3} {:nested #{1 2 3}}])))
   (testing "When not the same"
-    (is (= "[nil (not= 1 2)]"
+    (is (= "[nil (not= #_ (same :a) 1 2)]"
            (pr-str (=?/=?-diff* [(=?/same :a) (=?/same :a)] [1 2]))))
-    (is (= "[nil (not= 1 2) nil (not= 2 3)]"
+    (is (= "[nil (not= #_ (same :a) 1 2) nil (not= #_ (same :b) 2 3)]"
            (pr-str (=?/=?-diff* [(=?/same :a) (=?/same :a)
                                  (=?/same :b) (=?/same :b)]
                                 [1 2 2 3]))))
     (testing "Not the same and nested"
-      (is (= "[nil {:nested (not= 1 2)}]"
+      (is (= "[nil {:nested (not= #_ (same :a) 1 2)}]"
              (pr-str (=?/=?-diff* [(=?/same :a) {:nested (=?/same :a)}] [1 {:nested 2}])))))))


### PR DESCRIPTION
When you have an unknown value that needs to repeat in the expected assertion you don't have a lot of good options. You can let the result, and pull out as many values as you want to check but this quickly gets cumbersome, where the structure of actual needs to be declared twice, once to pull out the values to check and again in expected.

In this case, we want to assert, that `<id1>` and `<id2>` are the same across the actual value. We can do this with `=?/same`

```
(let [actual [{:id <id1> :ref [:field <id1>]}
              {:id <id2> :ref [:field <id2>]}]
      id1 (get-in actual [0 :id])
      id2 (get-in actual [1 :id])]
  (is (=? [{:id id1 :ref [:field id1]} {:id id2 :ref [:field id2] actual)))

(let [actual [{:id <id1> :ref [:field <id1>]}
              {:id <id2> :ref [:field <id2>]}]]
  (is (=? [{:id (=?/same :id1) :ref [:field (=?/same :id1)]}
           {:id (=?/same :id2) :ref [:field (=?/same :id2)]}]
           actual)))
```