### PR TITLE
Removing dependency algo.generic

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,6 @@
   pjstadig/humane-test-output {:mvn/version "0.11.0"}
   prismatic/schema            {:mvn/version "1.4.1"}
   metosin/malli               {:mvn/version "0.17.0"}
-  org.clojure/algo.generic    {:mvn/version "1.0.1"}
   org.clojure/java.classpath  {:mvn/version "1.1.0"}
   org.clojure/tools.namespace {:mvn/version "1.5.0"}}
 

--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -1,7 +1,6 @@
 (ns mb.hawk.assert-exprs.approximately-equal
   "See documentation in `docs/approximately-equal.md`."
   (:require
-   [clojure.algo.generic.math-functions :as algo.generic.math]
    [clojure.pprint :as pprint]
    [malli.core :as m]
    [malli.error :as me]
@@ -213,11 +212,17 @@
    :prefix "(approx " :suffix ")"
    (pprint/write-out [(.expected this) (.epsilon this)])))
 
+(defn- approx=
+  "Return true if the absolute value of the difference between x and y is less than eps.
+   Simple replacement for algo.generic.math/approx="
+  [x y eps]
+  (< (Math/abs (- (double x) (double y))) (double eps)))
+
 (methodical/defmethod =?-diff [Approx Number]
   [^Approx this actual]
   (let [expected (.expected this)
         epsilon  (.epsilon this)]
-    (when-not (algo.generic.math/approx= expected actual epsilon)
+    (when-not (approx= expected actual epsilon)
       (list 'not (list 'approx expected actual (symbol "#_epsilon") epsilon)))))
 
 (deftype Same [k])


### PR DESCRIPTION
We lean on `algo.generic` for a single call to `approx=` and it causes a number of warnings downstream

Running MB backend before:
```bash
(p) tplude ~ MB_EDITION=ee clj -M:dev:drivers:ee:ee-dev:cider/nrepl
2025-06-10 18:58:42,832 INFO metabase.util :: Maximum memory available to JVM: 9.0 GB
Reflection warning, clojure/algo/generic/math_functions.clj:103:3 - call to static method abs on java.lang.Math can't be resolved (argument types: unknown).
Reflection warning, clojure/algo/generic/math_functions.clj:107:4 - reference to field abs can't be resolved.
Reflection warning, clojure/algo/generic/math_functions.clj:109:4 - call to method abs can't be resolved (target class is unknown).
Reflection warning, clojure/algo/generic/math_functions.clj:113:3 - reference to field abs can't be resolved.
Reflection warning, clojure/algo/generic/math_functions.clj:117:13 - reference to field bipart can't be resolved.
Reflection warning, clojure/algo/generic/math_functions.clj:118:40 - reference to field lpart can't be resolved.
Reflection warning, clojure/algo/generic/math_functions.clj:119:46 - reference to field bipart can't be resolved.
Reflection warning, clojure/algo/generic/math_functions.clj:148:26 - call to static method round on java.lang.Math can't be resolved (argument types: unknown).
Reflection warning, clojure/algo/generic/math_functions.clj:148:26 - call to static method round on java.lang.Math can't be resolved (argument types: unknown).
Reflection warning, clojure/algo/generic/math_functions.clj:160:3 - call to method round can't be resolved (target class is unknown).
nREPL server started on port 54321 on host localhost - nrepl://localhost:54321
```

Running MB backend after (and removing [this](https://github.com/metabase/metabase/blob/1e0151089e1dc4a53bfea3ecbc7d8150c1b44abc/deps.edn#L262)):
```bash
(p) tplude ~ MB_EDITION=ee clj -M:dev:drivers:ee:ee-dev:cider/nrepl
2025-06-10 20:38:55,452 INFO metabase.util :: Maximum memory available to JVM: 9.0 GB
nREPL server started on port 54321 on host localhost - nrepl://localhost:54321
```