### PR TITLE
Handle nil values appropriately in approximately-equal

### DIFF
--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -77,6 +77,11 @@
   (when-not (pred actual)
     (list 'not (list pred actual))))
 
+(methodical/defmethod =?-diff [clojure.lang.AFunction nil]
+  [pred actual]
+  (when-not (pred actual)
+    (list 'not (list pred actual))))
+
 (methodical/defmethod =?-diff [clojure.lang.Sequential clojure.lang.Sequential]
   [expected actual]
   (let [same-size? (= (count expected)

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -12,6 +12,8 @@
     (is (=? 100 100)))
   (testing "predicate function"
     (is (=? int? 100)))
+  (testing "predicate function with nil"
+    (is (=? empty? nil)))
   (testing "regexes"
     (is (=? #"cans$" "cans")))
   (testing "classes"
@@ -36,15 +38,17 @@
           []))
   (is (=? [nil]
           [nil]))
+  (is (=? [nil?]
+          [nil]))
   (is (=? [1 nil 2]
           [1 nil 2]))
   (is (=? [:a int?]
           [:a 100]))
-  (testing "Should enforce that sequences are of the same length"
-    (is (= [nil nil (list 'not= nil? nil)]
-           (=?/=?-diff [int? string? nil?]
+  (testing "Should handle different lengths appropriately"
+    (is (= [nil nil (list 'not (list some? nil))]
+           (=?/=?-diff [int? string? some?]
                        [1 "two"])))
-    (is (= [nil nil (list 'not= nil? nil) (list 'not= nil "cans")]
+    (is (= [nil nil nil (list 'not= nil "cans")]
            (=?/=?-diff [int? string? nil?]
                        [1 "two" nil "cans"])))
     (testing "Differentiate between [1 2 nil] and [1 2]"


### PR DESCRIPTION
It's nice to be able to assert `empty?` on a coll that could be `nil`. It also seems we should be able to assert `nil?` on `nil`. Seemed like a bug!

```
(deftest failing-test
  (is (=? empty? nil)))
  
(deftest still-failing-test
  (is (=? nil? nil)))
```

The issue is that `(= nil (type nil))`.