### PR TITLE
Fix =? with missing map keys and a predicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom.xml
 pom.xml.asc
 # malli + clj-kondo: ignore malli-types
 .clj-kondo/metosin/malli-types-clj
+.calva/
+.DS_STORE

--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -107,12 +107,12 @@
 
 (methodical/defmethod =?-diff [clojure.lang.IPersistentMap clojure.lang.IPersistentMap]
   [expected-map actual-map]
-  (not-empty (into {} (for [[k expected] expected-map
-                            :let         [diff (if (contains? actual-map k)
-                                                 (=?-diff expected (get actual-map k))
-                                                 (symbol "nil #_\"key is not present.\""))]
-                            :when        diff]
-                        [k diff]))))
+  (not-empty (into {} (for [[expected-key expected-val] expected-map
+                            :let [diff (if (contains? actual-map expected-key)
+                                         (=?-diff expected-val (get actual-map expected-key))
+                                         (symbol "nil #_\"key is not present.\""))]
+                            :when diff]
+                        [expected-key diff]))))
 
 (deftype Exactly [expected])
 

--- a/src/mb/hawk/assert_exprs/approximately_equal.clj
+++ b/src/mb/hawk/assert_exprs/approximately_equal.clj
@@ -108,8 +108,9 @@
 (methodical/defmethod =?-diff [clojure.lang.IPersistentMap clojure.lang.IPersistentMap]
   [expected-map actual-map]
   (not-empty (into {} (for [[k expected] expected-map
-                            :let         [actual (get actual-map k (symbol "nil #_\"key is not present.\""))
-                                          diff   (=?-diff expected actual)]
+                            :let         [diff (if (contains? actual-map k)
+                                                 (=?-diff expected (get actual-map k))
+                                                 (symbol "nil #_\"key is not present.\""))]
                             :when        diff]
                         [k diff]))))
 

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -35,6 +35,22 @@
       (is (=? {:a 100}
               {:a 100, :b 200})))))
 
+(deftest ^:parallel missing-key-test
+  (testing "A key in expected and missing in actual should always fail"
+    (is (= {:k (symbol "nil #_\"key is not present.\"")}
+           (=?/=?-diff {:k some?} {})))
+    (is (= {:k (symbol "nil #_\"key is not present.\"")}
+           (=?/=?-diff {:k any?} {})))
+    (is (= {:k (symbol "nil #_\"key is not present.\"")}
+           (=?/=?-diff {:k nil?} {})))
+    (is (= {:k (symbol "nil #_\"key is not present.\"")}
+           (=?/=?-diff {:k 1} {})))
+    (is (= {:a {:k (symbol "nil #_\"key is not present.\"")}}
+           (=?/=?-diff {:a {:k some?}} {:a {}})))
+    (is (=? {:k some?}
+            {:k 1}))
+    (is (nil? (=?/=?-diff {:k nil?} {:k nil})))))
+
 (deftest ^:parallel sequences-test
   (is (=? []
           []))

--- a/test/mb/hawk/assert_exprs/approximately_equal_test.clj
+++ b/test/mb/hawk/assert_exprs/approximately_equal_test.clj
@@ -37,18 +37,12 @@
 
 (deftest ^:parallel missing-key-test
   (testing "A key in expected and missing in actual should always fail"
-    (is (= {:k (symbol "nil #_\"key is not present.\"")}
-           (=?/=?-diff {:k some?} {})))
-    (is (= {:k (symbol "nil #_\"key is not present.\"")}
-           (=?/=?-diff {:k any?} {})))
-    (is (= {:k (symbol "nil #_\"key is not present.\"")}
-           (=?/=?-diff {:k nil?} {})))
-    (is (= {:k (symbol "nil #_\"key is not present.\"")}
-           (=?/=?-diff {:k 1} {})))
+    (are [expected-val] (= {:k (symbol "nil #_\"key is not present.\"")}
+                           (=?/=?-diff {:k expected-val} {}))
+      some? any? nil? 1)
     (is (= {:a {:k (symbol "nil #_\"key is not present.\"")}}
            (=?/=?-diff {:a {:k some?}} {:a {}})))
-    (is (=? {:k some?}
-            {:k 1}))
+    (is (=? {:k some?} {:k 1}))
     (is (nil? (=?/=?-diff {:k nil?} {:k nil})))))
 
 (deftest ^:parallel sequences-test


### PR DESCRIPTION
Closes https://github.com/metabase/hawk/issues/37

When an `expected` key wasn't in the `actual` map, we were returning `(symbol "nil #_\"key is not present.\"")` and then diffing that with the expected value, but this would erroneously return no diff if the expected value was a predicate like `some?` or `any?`. The fix in this PR is to only diff with the expected value if the `expected` key is in the `actual` map. 